### PR TITLE
Add dependency on suturo_msgs for travis

### DIFF
--- a/dependencies.rosinstall
+++ b/dependencies.rosinstall
@@ -1,4 +1,8 @@
 - git:
+    local-name: suturo_msgs
+    uri: https://github.com/suturo16/suturo_msgs.git
+
+- git:
     local-name: giskard
     uri: https://github.com/suturo16/giskard.git
     version: feature/expressionExtension


### PR DESCRIPTION
Irgendwann werden die suturo_msgs zum Bauen benötigt werden. Daher sind sie jetzt auch in den dependencies die Travis sich zieht.